### PR TITLE
Update monster-card.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,24 @@ Provide additional configuration options to entities:
           type: "custom:state-card-custom"
 ```
 
+On filtred entity click event, call a service for that specific entity_id(this.entity_id):
+``` yaml
+- type: 'custom:monster-card'
+card:
+  type: glance
+filter:
+  include:
+    - entity_id: binary_sensor.visonic*
+      attributes:
+        "state": "On"
+      options:
+        tap_action:
+          action: call-service
+          service: visonic.alarm_sensor_bypass
+          service_data:
+            bypass: 'True'
+            entity_id: this.entity_id
+```
 ## Sorting entities explained
 
 Entities are displayed in the card in the order they are matched by the include filters. I.e. to get a specific order, detailed filters must precede more general ones.

--- a/monster-card.js
+++ b/monster-card.js
@@ -61,7 +61,8 @@ class MonsterCard extends HTMLElement {
 
       Object.keys(hass.states).sort().forEach(key => {
         if (filters.every(filterFunc => filterFunc(hass.states[key]))) {
-          entities.set(hass.states[key].entity_id, Object.assign({ "entity": hass.states[key].entity_id }, options));
+          const dynOptions = JSON.parse(JSON.stringify(options).replace(/this.entity_id/g,hass.states[key].entity_id));
+          entities.set(hass.states[key].entity_id, Object.assign({ "entity": hass.states[key].entity_id }, dynOptions));
         }
       });
     });


### PR DESCRIPTION
A monstruously awesome way to execute services dynamic over each filtred entity.

Imagine a use case where we need an adaptive card for showing triggered alarmed sensors( like an open window) that prevent us to arm your alarm.
The monster-card can easily filter that sensors and call a service by configuring a tap-action but in that case we need to provide the choosen / clicked entity_id to the service call.

Here is a sample of what i mean:

```
- type: 'custom:monster-card'
card:
  type: glance
filter:
  include:
    - entity_id: binary_sensor.visonic*
      attributes:
        "state": "On"
      options:
        tap_action:
          action: call-service
          service: visonic.alarm_sensor_bypass
          service_data:
            bypass: 'True'
            entity_id: this.entity_id
```
This commit parse the options object to replace the "this.entity_id" string with the real filtered iterated object entity_id.