### PR TITLE
Groups filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,19 @@ Show all lights that are on (two methods):
       - state: 'unavailable'
 ```
 
+Show all entities in automation group group.water_leak that are on.
+```yaml
+- type: 'custom:monster-card'
+  show_empty: true
+  card:
+    show_state: false
+    title: Water leak
+    type: glance
+  filter:
+    include:
+      - group: water_leak
+        state: 'on'
+```
 
 Show all in `device_tracker` with battery lower than 25:
 ```yaml

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Filter options for `include` and `exclude`:
 | Name | Type | Default | Description
 | ---- | ---- | ------- | -----------
 | domain | string | optional | Filter all entities that match the domain
+| group | string | optional | Filter all entities that are in an automation group
 | state | string | optional | Match entities that match state. Note, in YAML, make sure you wrap it in quotes to make sure it is parsed as a string.
 | entity_id | string | optional | Filter entities by id, supports wildcards (`*living_room*`). Case insensitive
 | name | string | optional | Filter entities by friendly_name or title, supports wildcards (`*kitchen*`). Case insensitive

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Show all lights that are on (two methods):
       - state: 'unavailable'
 ```
 
-Show all entities in automation group group.water_leak that are on.
+Show all entities in automation group `group.water_leak` that are on.
 ```yaml
 - type: 'custom:monster-card'
   show_empty: true

--- a/monster-card.js
+++ b/monster-card.js
@@ -39,6 +39,12 @@ class MonsterCard extends HTMLElement {
     const entities = new Map();
     filters.forEach((filter) => {
       const filters = [];
+	  if (filter.group) {
+		if (filter.group in hass.states){
+			const entities = hass.states[filter.group].attributes['entity_id'];
+			filters.push(stateObj => entities.includes(stateObj.entity_id));
+		}
+	  }
       if (filter.domain) {
         filters.push(stateObj => stateObj.entity_id.split('.', 1)[0] === filter.domain);
       }

--- a/monster-card.js
+++ b/monster-card.js
@@ -40,8 +40,9 @@ class MonsterCard extends HTMLElement {
     filters.forEach((filter) => {
       const filters = [];
 	  if (filter.group) {
-		if (filter.group in hass.states){
-			const entities = hass.states[filter.group].attributes['entity_id'];
+		const group_id = 'group.'+filter.group
+		if (group_id in hass.states){
+			const entities = hass.states[group_id].attributes['entity_id'];
 			filters.push(stateObj => entities.includes(stateObj.entity_id));
 		}
 	  }


### PR DESCRIPTION
adds filtering by automation group in monster-card. E.g.

```
- type: 'custom:monster-card'
  show_empty: true
  card:
    show_state: false
    title: Water leak
    type: glance
  filter:
    include:
      - group: water_leak
        state: 'on'
```